### PR TITLE
Optimize strings

### DIFF
--- a/Display.cs
+++ b/Display.cs
@@ -1,41 +1,42 @@
+using System.Buffers;
+using System.Runtime.InteropServices;
+
 namespace digit_console;
 
 public class Display
 {
-    public static string GetImagesAsString(List<int> image1, List<int> image2)
+    public static void GetImagesChars(int[] image1, int[] image2, Span<char> span)
     {
-        var first_image = GetImageAsString(image1);
-        var first = first_image.Split("\n");
-        var second_image = GetImageAsString(image2);
-        var second = second_image.Split("\n");
-        string result = "";
+
+        var first = image1.AsSpan();
+        var second = image2.AsSpan();
+
         for (int i = 0; i < 28; i++)
         {
-            result += first[i];
-            result += " | ";
-            result += second[i];
-            result += "\n";
-        }
-        return result;
-    }
-
-    public static string GetImageAsString(List<int> image)
-    {
-        string result = "";
-        int count = 0;
-        foreach (int pixel in image)
-        {
-            if (count % 28 == 0 && count != 0)
+            foreach (var pixel in first.Slice(0, 28))
             {
-                result += "\n";
+                span[0] = span[1] = GetDisplayCharForPixel(pixel);
+                span = span.Slice(2);
             }
-            var output_char = GetDisplayCharForPixel(pixel);
-            result += output_char;
-            result += output_char;
-            count++;
+
+            first = first.Slice(28);
+
+            span[0] = ' ';
+            span[1] = '|';
+            span[2] = ' ';
+            span = span.Slice(3);
+
+            foreach (var pixel in second.Slice(0, 28))
+            {
+                span[0] = span[1] = GetDisplayCharForPixel(pixel);
+                span = span.Slice(2);
+            }
+
+            second = second.Slice(28);
+
+            span[0] = '\n';
+            span = span.Slice(1);
         }
-        result += "\n";
-        return result;
     }
 
     private static char GetDisplayCharForPixel(int pixel)

--- a/Loader.cs
+++ b/Loader.cs
@@ -41,7 +41,7 @@ public class FileLoader
             image.Add(item);
         }
 
-        return new Record(value, image);
+        return new Record(value, image.ToArray());
     }
 
     private static (List<Record>, List<Record>) SplitDataSets(List<Record> data, int offset, int count)

--- a/Program.cs
+++ b/Program.cs
@@ -93,9 +93,6 @@ static async Task Listen(ChannelReader<Prediction> reader,
     }
 }
 
-string Spaces = new string(' ', 46);
-string EqualsLine = new string('=', 115);
-
 static void DisplayImages(Prediction prediction, bool scroll)
 {
     if (!scroll)

--- a/Recognize.cs
+++ b/Recognize.cs
@@ -15,7 +15,7 @@ public abstract class Classifier
     public Prediction Predict(Record input)
     {
         int best_total = int.MaxValue;
-        Record best = new(0, new List<int>());
+        Record best = new(0, Array.Empty<int>());
         foreach (Record candidate in TrainingData)
         {
             int total = 0;

--- a/Shared.cs
+++ b/Shared.cs
@@ -1,5 +1,5 @@
 namespace digits
 {
-    public record Record (int Value, List<int> Image);
+    public record Record (int Value, int[] Image);
     public record Prediction (Record Actual, Record Predicted);
 }

--- a/Strings.cs
+++ b/Strings.cs
@@ -1,0 +1,7 @@
+﻿namespace digits;
+
+public class Strings
+{
+    public static readonly string Spaces46 = new string(' ', 46);
+    public static readonly string Equals115 = new string('=', 115);
+}


### PR DESCRIPTION
There were a LOT of string allocations going on in the Display class, so I started optimizing them and may have got a bit carried away because I think I've got rid of about 99.9% of them.

It cuts about 33% off the runtime for `-c 2000`

I will absolutely not be offended in any way if you don't want to merge this, I had fun writing it.